### PR TITLE
build: bump node version for github workflows

### DIFF
--- a/.github/actions/setup-workflow/action.yml
+++ b/.github/actions/setup-workflow/action.yml
@@ -10,7 +10,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         always-auth: true
-        node-version: 16.x
+        node-version: 18.x
         registry-url: https://registry.npmjs.org
 
     - name: Retrieve Yarn Cache Directory


### PR DESCRIPTION
## Description

- bump node version for github workflows from 16.x to 18.x

## Type of change

- [x] Chore
- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Revert
